### PR TITLE
Fix avdl files to add import and not use 'package'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,4 +47,12 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.9.2</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/avro/fileOne.avdl
+++ b/src/main/avro/fileOne.avdl
@@ -1,4 +1,4 @@
-@namespace("com.my.package.one")
+@namespace("com.my.pkg.one")
 protocol ProtocolOne {
     record MyRecord {
         string id;

--- a/src/main/avro/fileTwo.avdl
+++ b/src/main/avro/fileTwo.avdl
@@ -1,10 +1,12 @@
-@namespace("com.my.package.two")
+@namespace("com.my.pkg.two")
 protocol ProtocolTwo {
+    import idl "fileOne.avdl";
+
     record MyRecord {
         string id;
     }
 
     record UsesMyRecord {
-        com.my.package.one.MyRecord myRecord;
+        com.my.pkg.one.MyRecord myRecord;
     }
 }


### PR DESCRIPTION
Was missing an import statement in my example in https://github.com/makubi/avrohugger-maven-plugin/issues/25 as well as Java complaining that the package source had a keyword 'package' in it